### PR TITLE
fix silent crash when using special characters and trying to shorten string for display

### DIFF
--- a/dashcols/services/DashCols_AttributesService.php
+++ b/dashcols/services/DashCols_AttributesService.php
@@ -162,8 +162,8 @@ class DashCols_AttributesService extends BaseApplicationComponent
 					
 					// Ye olde generic string, I guess.
 					$attributeHtml = trim( strip_tags( $this->_attribute ) );
-					if ( strlen( $attributeHtml ) > 47 ) {
-						$attributeHtml = substr( $attributeHtml, 0, 47 ) . '...';
+					if ( mb_strlen( $attributeHtml ) > 47 ) {
+						$attributeHtml = mb_substr( $attributeHtml, 0, 47 ) . '...';
 					}
 
 				}


### PR DESCRIPTION
On the entry list, if the field is too long, and the plugin tries to shorten it in the middle of a special character, the functions silently crashes, and the JSON returned from AJAX is invalid with an empty 'html' field. This causes Craft CP to show 'an unknown error has occured' and no entries get listed.
